### PR TITLE
spec: fixup py2 require for requests; bump release

### DIFF
--- a/python-requests-aws.spec
+++ b/python-requests-aws.spec
@@ -23,7 +23,7 @@
 
 Name:           python-%{pkgname}
 Version:        0.1.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        %{sum}
 
 License:        BSD licence
@@ -38,7 +38,7 @@ BuildArch:      noarch
 
 %package -n python2-%{pkgname}
 Summary:        %{sum}
-Requires:       python2-requests
+Requires:       python-requests
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 Provides:       python-requests-aws


### PR DESCRIPTION
el6 systems has python-requests, not python2-requests.